### PR TITLE
Use `mk_solver` instead of `mk_simple_solver`

### DIFF
--- a/lib/interpret.mli
+++ b/lib/interpret.mli
@@ -1,1 +1,2 @@
-include Interpret_intf.Intf (** @inline *)
+(** @inline *)
+include Interpret_intf.Intf

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,1 +1,2 @@
-include Solver_intf.Intf (** @inline *)
+(** @inline *)
+include Solver_intf.Intf

--- a/lib/z3_mappings.ml
+++ b/lib/z3_mappings.ml
@@ -594,12 +594,13 @@ module Fresh = struct
 
     module Solver = struct
       let make ?logic () : solver =
-        match logic with
-        | Some logic ->
-          let logic = Format.asprintf "%a" Ty.pp_logic logic in
-          let logic = Z3.Symbol.mk_string ctx logic in
-          Z3.Solver.mk_solver ctx (Some logic)
-        | None -> Z3.Solver.mk_simple_solver ctx
+        let logic =
+          Option.map
+            (fun l ->
+              Format.kasprintf (Z3.Symbol.mk_string ctx) "%a" Ty.pp_logic l )
+            logic
+        in
+        Z3.Solver.mk_solver ctx logic
 
       let add_simplifier solver =
         let simplify = Z3.Simplifier.mk_simplifier ctx "simplify" in

--- a/lib/z3_mappings.mli
+++ b/lib/z3_mappings.mli
@@ -2,4 +2,5 @@ module Fresh : sig
   module Make () : Mappings_intf.S
 end
 
-include Mappings_intf.S (** @inline *)
+(** @inline *)
+include Mappings_intf.S


### PR DESCRIPTION
Basing on this: https://github.com/Z3Prover/z3/issues/1035

However, now when not specifying a logic `smtml` is slower on file-per-file basis