### PR TITLE
Add parametric `mappings.ml`

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -12,12 +12,14 @@ let parse_file file = get_contents file |> Parse.from_string
 
 type prover =
   | Z3_prover
+  | Z3_prover2
   | Colibri2_prover
 
 let prover_conv =
   Cmdliner.Arg.enum
     [ ("z3", Z3_prover)
     ; ("Z3", Z3_prover)
+    ; ("z3_2", Z3_prover2)
     ; ("c2", Colibri2_prover)
     ; ("colibri2", Colibri2_prover)
     ; ("Colibri2", Colibri2_prover)
@@ -28,6 +30,7 @@ let parse_cmdline =
     let module Mappings =
       ( val match prover with
             | Z3_prover -> (module Z3_mappings)
+            | Z3_prover2 -> (module Z3_mappings2)
             | Colibri2_prover ->
               Log.err "Please install Colibri2 and use 'smtml2'"
           : Mappings_intf.S )

--- a/lib/dune
+++ b/lib/dune
@@ -17,6 +17,7 @@
   interpret_intf
   lexer
   log
+  mappings
   mappings_intf
   model
   num
@@ -30,7 +31,8 @@
   symbol
   ty
   value
-  z3_mappings)
+  z3_mappings
+  z3_mappings2)
  (private_modules lexer parser)
  (libraries hc z3 ocaml_intrinsics)
  (instrumentation

--- a/lib/mappings.ml
+++ b/lib/mappings.ml
@@ -1,0 +1,713 @@
+include Mappings_intf
+
+module Make (M : Mappings_intf.M) = struct
+  open M
+  open Ty
+  open Cont
+
+  type 'a with_cont =
+    { node : 'a
+    ; cont : M.cont
+    }
+
+  type model = M.model with_cont
+
+  type solver = M.solver with_cont
+
+  type handle = M.handle
+
+  type optimize = M.optimizer with_cont
+
+  let err = Log.err
+
+  let get_type = function
+    | Ty_int -> Types.int
+    | Ty_real -> Types.real
+    | Ty_bool -> Types.bool
+    | Ty_str -> Types.string
+    | Ty_bitv 8 -> Types.bitv 8
+    | Ty_bitv 32 -> Types.bitv 32
+    | Ty_bitv 64 -> Types.bitv 64
+    | Ty_fp 32 -> Types.float 8 24
+    | Ty_fp 64 -> Types.float 11 53
+    | Ty_bitv _ | Ty_fp _ -> assert false
+
+  module Bool_impl = struct
+    let true_ = true_
+
+    let false_ = false_
+
+    let unop = function
+      | Not -> not_
+      | op -> err {|Bool: Unsupported Z3 unop operator "%a"|} Ty.pp_unop op
+
+    let binop = function
+      | And -> and_
+      | Or -> or_
+      | Xor -> xor
+      | op -> err {|Bool: Unsupported Z3 binop operator "%a"|} Ty.pp_binop op
+
+    let triop = function
+      | Ite -> ite
+      | op -> err {|Bool: Unsupported Z3 triop operator "%a"|} Ty.pp_triop op
+
+    let relop op e1 e2 =
+      match op with
+      | Eq -> eq e1 e2
+      | Ne -> distinct [ e1; e2 ]
+      | _ -> err {|Bool: Unsupported Z3 relop operator "%a"|} Ty.pp_relop op
+
+    let cvtop _op _e = assert false
+  end
+
+  module Int_impl = struct
+    let v i = int i [@@inline]
+
+    let unop = function
+      | Neg -> Int.neg
+      | op -> err {|Int: Unsupported unop operator "%a"|} Ty.pp_unop op
+
+    let binop = function
+      | Add -> Int.add
+      | Sub -> Int.sub
+      | Mul -> Int.mul
+      | Div -> Int.div
+      | Rem -> Int.rem
+      | Pow -> Int.pow
+      | op -> err {|Int: Unsupported binop operator "%a"|} Ty.pp_binop op
+
+    let relop = function
+      | Eq -> eq
+      | Ne -> fun e1 e2 -> distinct [ e1; e2 ]
+      | Lt -> Int.lt
+      | Gt -> Int.gt
+      | Le -> Int.le
+      | Ge -> Int.ge
+      | op -> err {|Int: Unsupported relop operator "%a"|} Ty.pp_relop op
+
+    (* TODO: Uninterpreted cvtops *)
+    let cvtop op e =
+      match op with
+      | ToString -> assert false
+      | OfString -> assert false
+      | Reinterpret_float -> Real.to_int e
+      | op -> err {|Int: Unsupported cvtop operator "%a"|} Ty.pp_cvtop op
+  end
+
+  module Real_impl = struct
+    let v f = real f [@@inline]
+
+    let unop op e =
+      match op with
+      | Neg -> Real.neg e
+      | Abs ->
+        let* zero = real 0. in
+        let* e_gt_zero = Real.gt e zero in
+        let* neg_e = Real.neg e in
+        ite e_gt_zero e neg_e
+      | Sqrt -> bind (v 0.5) (Real.pow e)
+      | Ceil ->
+        let* x_int = Real.to_int e in
+        let* x_int_real = Int.to_real x_int in
+        let* x_int_real_eq_e = eq x_int_real e in
+        let* x_int_add_one = bind (int 1) (Int.add x_int) in
+        ite x_int_real_eq_e x_int x_int_add_one
+      | Floor -> Real.to_int e
+      | Nearest | Is_nan | _ ->
+        err {|Real: Unsupported unop operator "%a"|} Ty.pp_unop op
+
+    let binop op e1 e2 =
+      match op with
+      | Add -> Real.add e1 e2
+      | Sub -> Real.sub e1 e2
+      | Mul -> Real.mul e1 e2
+      | Div -> Real.div e1 e2
+      | Pow -> Real.pow e1 e2
+      | Min ->
+        let* e1_le_e2 = Real.le e1 e2 in
+        ite e1_le_e2 e1 e2
+      | Max ->
+        let* e1_ge_e2 = Real.ge e1 e2 in
+        ite e1_ge_e2 e1 e2
+      | _ -> err {|Real: Unsupported binop operator "%a"|} Ty.pp_binop op
+
+    let relop op e1 e2 =
+      match op with
+      | Eq -> eq e1 e2
+      | Ne -> distinct [ e1; e2 ]
+      | Lt -> Real.lt e1 e2
+      | Gt -> Real.gt e1 e2
+      | Le -> Real.le e1 e2
+      | Ge -> Real.ge e1 e2
+      | _ -> err {|Real: Unsupported relop operator "%a"|} Ty.pp_relop op
+
+    (* TODO: Uninterpreted cvtops *)
+    let cvtop op e =
+      match op with
+      | ToString -> assert false
+      | OfString -> assert false
+      | ConvertUI32 -> assert false
+      | Reinterpret_int -> Int.to_real e
+      | op -> err {|Real: Unsupported cvtop operator "%a"|} Ty.pp_cvtop op
+  end
+
+  module String_impl = struct
+    let v s = String.v s [@@inline]
+
+    (* let trim = FuncDecl.mk_func_decl_s ctx "Trim" [ str_sort ] str_sort *)
+
+    let unop = function
+      | Len -> String.length
+      | Trim ->
+        (* FuncDecl.apply trim [ e ] *)
+        assert false
+      | op -> err {|String: Unsupported unop operator "%a"|} Ty.pp_unop op
+
+    let binop op e1 e2 =
+      match op with
+      | Nth -> String.at e1 ~pos:e2
+      | Concat -> String.concat e1 e2
+      | _ -> err {|String: Unsupported binop operator "%a"|} Ty.pp_binop op
+
+    let triop op e1 e2 e3 =
+      match op with
+      | Substr -> String.sub e1 ~pos:e2 ~len:e3
+      | _ -> err {|String: Unsupported triop operator "%a"|} Ty.pp_triop op
+
+    let relop op e1 e2 =
+      match op with
+      | Eq -> eq e1 e2
+      | Ne -> distinct [ e1; e2 ]
+      | _ -> err {|String: Unsupported relop operator "%a"|} Ty.pp_relop op
+
+    let cvtop = function
+      | String_to_code -> String.to_code
+      | String_from_code -> String.of_code
+      | op -> err {|String: Unsupported cvtop operator "%a"|} Ty.pp_cvtop op
+  end
+
+  module type Bitv_sig = sig
+    type elt
+
+    val v : elt -> term M.t
+
+    val bitwidth : int
+
+    module Ixx : sig
+      val of_int : int -> elt
+
+      val shift_left : elt -> int -> elt
+    end
+  end
+
+  module Bitv_impl (B : Bitv_sig) = struct
+    include B
+
+    (* Stolen from @krtab in OCamlPro/owi #195 *)
+    let clz n =
+      let rec loop (lb : int) (ub : int) =
+        if ub = lb + 1 then v @@ Ixx.of_int (bitwidth - ub)
+        else
+          let mid = (lb + ub) / 2 in
+          let pow_two_mid = Ixx.(shift_left (of_int 1) mid) in
+          let* pow_two_mid = v pow_two_mid in
+          let* n_lt_pow_two = Bitv.lt_u n pow_two_mid in
+          let* left = loop lb mid in
+          let* right = loop mid ub in
+          ite n_lt_pow_two left right
+      in
+      let* zero = v (Ixx.of_int 0) in
+      let* n_eq_zero = eq n zero in
+      let* bitwidth' = v (Ixx.of_int bitwidth) in
+      let* right = loop 0 bitwidth in
+      ite n_eq_zero bitwidth' right
+
+    (* Stolen from @krtab in OCamlPro/owi #195 *)
+    let ctz n =
+      let* zero = v (Ixx.of_int 0) in
+      let rec loop (lb : int) (ub : int) =
+        if ub = lb + 1 then v (Ixx.of_int lb)
+        else
+          let mid = (lb + ub) / 2 in
+          let pow_two_mid = Ixx.(shift_left (of_int 1) mid) in
+          let* pow_two_mid = v pow_two_mid in
+          let* rem_pow_two = Bitv.rem n pow_two_mid in
+          let* rem_pow_eq_zero = eq rem_pow_two zero in
+          let* right = loop mid ub in
+          let* left = loop lb mid in
+          ite rem_pow_eq_zero right left
+      in
+      let* n_eq_zero = eq n zero in
+      let* bitwidth' = v (Ixx.of_int bitwidth) in
+      let* right = loop 0 bitwidth in
+      ite n_eq_zero bitwidth' right
+
+    let unop = function
+      | Clz -> clz
+      | Ctz -> ctz
+      | Neg -> Bitv.neg
+      | Not -> Bitv.lognot
+      | op -> err {|Bitv: Unsupported unary operator "%a"|} Ty.pp_unop op
+
+    let binop = function
+      | Add -> Bitv.add
+      | Sub -> Bitv.sub
+      | Mul -> Bitv.mul
+      | Div -> Bitv.div
+      | DivU -> Bitv.div_u
+      | And -> Bitv.logand
+      | Xor -> Bitv.logxor
+      | Or -> Bitv.logor
+      | Shl -> Bitv.shl
+      | ShrA -> Bitv.ashr
+      | ShrL -> Bitv.lshr
+      | Rem -> Bitv.rem
+      | RemU -> Bitv.rem_u
+      | Rotl -> Bitv.rotate_left
+      | Rotr -> Bitv.rotate_right
+      | op -> err {|Bitv: Unsupported binary operator "%a"|} Ty.pp_binop op
+
+    let triop op _ =
+      err {|Bitv: Unsupported triop operator "%a"|} Ty.pp_triop op
+
+    let relop op e1 e2 =
+      match op with
+      | Eq -> eq e1 e2
+      | Ne -> distinct [ e1; e2 ]
+      | Lt -> Bitv.lt e1 e2
+      | LtU -> Bitv.lt_u e1 e2
+      | Le -> Bitv.le e1 e2
+      | LeU -> Bitv.le_u e1 e2
+      | Gt -> Bitv.gt e1 e2
+      | GtU -> Bitv.gt_u e1 e2
+      | Ge -> Bitv.ge e1 e2
+      | GeU -> Bitv.ge_u e1 e2
+
+    let cvtop op e =
+      match op with
+      | WrapI64 -> Bitv.extract e ~high:(bitwidth - 1) ~low:0
+      | ExtS n -> Bitv.sign_extend n e
+      | ExtU n -> Bitv.zero_extend n e
+      | TruncSF32 | TruncSF64 ->
+        let* rm = Float.Rounding_mode.rtz in
+        Float.to_sbv bitwidth ~rm e
+      | TruncUF32 | TruncUF64 ->
+        let* rm = Float.Rounding_mode.rtz in
+        Float.to_ubv bitwidth ~rm e
+      | Reinterpret_float -> Float.to_ieee_bv e
+      | ToBool ->
+        let* zero = v (Ixx.of_int 0) in
+        distinct [ e; zero ]
+      | OfBool ->
+        let* one = v (Ixx.of_int 1) in
+        let* zero = v (Ixx.of_int 0) in
+        ite e one zero
+      | _ -> assert false
+  end
+
+  module I8 = Bitv_impl (struct
+    type elt = int
+
+    let v i = Bitv.v (string_of_int i) 8
+
+    let bitwidth = 8
+
+    module Ixx = struct
+      let of_int i = i [@@inline]
+
+      let shift_left v i = v lsl i [@@inline]
+    end
+  end)
+
+  module I32 = Bitv_impl (struct
+    type elt = int32
+
+    let v i = Bitv.v (Int32.to_string i) 32
+
+    let bitwidth = 32
+
+    module Ixx = Int32
+  end)
+
+  module I64 = Bitv_impl (struct
+    type elt = int64
+
+    let v i = Bitv.v (Int64.to_string i) 64
+
+    let bitwidth = 64
+
+    module Ixx = Int64
+  end)
+
+  module type Float_sig = sig
+    type elt
+
+    val eb : int
+
+    val sb : int
+
+    val v : elt -> term M.t
+    (* TODO: *)
+    (* val to_string : Z3.FuncDecl.func_decl *)
+    (* val of_string : Z3.FuncDecl.func_decl *)
+  end
+
+  module Float_impl (F : Float_sig) = struct
+    include F
+
+    let unop op e =
+      match op with
+      | Neg -> Float.neg e
+      | Abs -> Float.abs e
+      | Sqrt ->
+        let* rne = Float.Rounding_mode.rne in
+        Float.sqrt ~rm:rne e
+      | Is_nan -> Float.is_nan e
+      | Ceil ->
+        let* rm = Float.Rounding_mode.rtp in
+        Float.round_to_integral ~rm e
+      | Floor ->
+        let* rm = Float.Rounding_mode.rtn in
+        Float.round_to_integral ~rm e
+      | Trunc ->
+        let* rm = Float.Rounding_mode.rtz in
+        Float.round_to_integral ~rm e
+      | Nearest ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.round_to_integral ~rm e
+      | _ -> err {|Fp: Unsupported Z3 unary operator "%a"|} Ty.pp_unop op
+
+    let binop op e1 e2 =
+      match op with
+      | Add ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.add ~rm e1 e2
+      | Sub ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.sub ~rm e1 e2
+      | Mul ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.mul ~rm e1 e2
+      | Div ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.div ~rm e1 e2
+      | Min -> Float.min e1 e2
+      | Max -> Float.max e1 e2
+      | Rem -> Float.rem e1 e2
+      | _ -> err {|Fp: Unsupported Z3 binop operator "%a"|} Ty.pp_binop op
+
+    let triop op _ =
+      err {|Fp: Unsupported Z3 triop operator "%a"|} Ty.pp_triop op
+
+    let relop op e1 e2 =
+      match op with
+      | Eq -> Float.eq e1 e2
+      | Ne ->
+        let* eq_ = Float.eq e1 e2 in
+        not_ eq_
+      | Lt -> Float.lt e1 e2
+      | Le -> Float.le e1 e2
+      | Gt -> Float.gt e1 e2
+      | Ge -> Float.ge e1 e2
+      | _ -> err {|Fp: Unsupported Z3 relop operator "%a"|} Ty.pp_relop op
+
+    let cvtop op e =
+      match op with
+      | PromoteF32 | DemoteF64 ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.to_fp eb sb ~rm e
+      | ConvertSI32 | ConvertSI64 ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.sbv_to_fp eb sb ~rm e
+      | ConvertUI32 | ConvertUI64 ->
+        let* rm = Float.Rounding_mode.rne in
+        Float.ubv_to_fp eb sb ~rm e
+      | Reinterpret_int -> Float.of_ieee_bv eb sb e
+      | ToString ->
+        (* TODO: FuncDecl.apply to_string [ e ] *)
+        assert false
+      | OfString ->
+        (* TODO: FuncDecl.apply of_string [ e ] *)
+        assert false
+      | _ -> err {|Fp: Unsupported Z3 cvtop operator "%a"|} Ty.pp_cvtop op
+  end
+
+  module Float32_impl = Float_impl (struct
+    type elt = int32
+
+    let eb = 8
+
+    let sb = 24
+
+    let v f = Float.v (Int32.float_of_bits f) eb sb
+
+    (* TODO: *)
+    (* let to_string = *)
+    (*   Z3.FuncDecl.mk_func_decl_s ctx "F32ToString" [ fp32_sort ] str_sort *)
+    (* let of_string = *)
+    (*   Z3.FuncDecl.mk_func_decl_s ctx "StringToF32" [ str_sort ] fp32_sort *)
+  end)
+
+  module Float64_impl = Float_impl (struct
+    type elt = int64
+
+    let eb = 11
+
+    let sb = 53
+
+    let v f = Float.v (Int64.float_of_bits f) eb sb
+
+    (* TODO: *)
+    (* let to_string = *)
+    (*   Z3.FuncDecl.mk_func_decl_s ctx "F64ToString" [ fp64_sort ] str_sort *)
+    (* let of_string = *)
+    (*   Z3.FuncDecl.mk_func_decl_s ctx "StringToF64" [ str_sort ] fp64_sort *)
+  end)
+
+  let v : Value.t -> term M.t = function
+    | True -> Bool_impl.true_
+    | False -> Bool_impl.false_
+    | Int v -> Int_impl.v v
+    | Real v -> Real_impl.v v
+    | Str v -> String_impl.v v
+    | Num (I8 x) -> I8.v x
+    | Num (I32 x) -> I32.v x
+    | Num (I64 x) -> I64.v x
+    | Num (F32 x) -> Float32_impl.v x
+    | Num (F64 x) -> Float64_impl.v x
+
+  let unop = function
+    | Ty.Ty_int -> Int_impl.unop
+    | Ty.Ty_real -> Real_impl.unop
+    | Ty.Ty_bool -> Bool_impl.unop
+    | Ty.Ty_str -> String_impl.unop
+    | Ty.Ty_bitv 8 -> I8.unop
+    | Ty.Ty_bitv 32 -> I32.unop
+    | Ty.Ty_bitv 64 -> I64.unop
+    | Ty.Ty_fp 32 -> Float32_impl.unop
+    | Ty.Ty_fp 64 -> Float64_impl.unop
+    | Ty.Ty_bitv _ | Ty_fp _ -> assert false
+
+  let binop = function
+    | Ty.Ty_int -> Int_impl.binop
+    | Ty.Ty_real -> Real_impl.binop
+    | Ty.Ty_bool -> Bool_impl.binop
+    | Ty.Ty_str -> String_impl.binop
+    | Ty.Ty_bitv 8 -> I8.binop
+    | Ty.Ty_bitv 32 -> I32.binop
+    | Ty.Ty_bitv 64 -> I64.binop
+    | Ty.Ty_fp 32 -> Float32_impl.binop
+    | Ty.Ty_fp 64 -> Float64_impl.binop
+    | Ty.Ty_bitv _ | Ty_fp _ -> assert false
+
+  let triop = function
+    | Ty.Ty_int | Ty.Ty_real -> assert false
+    | Ty.Ty_bool -> Bool_impl.triop
+    | Ty.Ty_str -> String_impl.triop
+    | Ty.Ty_bitv 8 -> I8.triop
+    | Ty.Ty_bitv 32 -> I32.triop
+    | Ty.Ty_bitv 64 -> I64.triop
+    | Ty.Ty_fp 32 -> Float32_impl.triop
+    | Ty.Ty_fp 64 -> Float64_impl.triop
+    | Ty.Ty_bitv _ | Ty_fp _ -> assert false
+
+  let relop = function
+    | Ty.Ty_int -> Int_impl.relop
+    | Ty.Ty_real -> Real_impl.relop
+    | Ty.Ty_bool -> Bool_impl.relop
+    | Ty.Ty_str -> String_impl.relop
+    | Ty.Ty_bitv 8 -> I8.relop
+    | Ty.Ty_bitv 32 -> I32.relop
+    | Ty.Ty_bitv 64 -> I64.relop
+    | Ty.Ty_fp 32 -> Float32_impl.relop
+    | Ty.Ty_fp 64 -> Float64_impl.relop
+    | Ty.Ty_bitv _ | Ty_fp _ -> assert false
+
+  let cvtop = function
+    | Ty.Ty_int -> Int_impl.cvtop
+    | Ty.Ty_real -> Real_impl.cvtop
+    | Ty.Ty_bool -> Bool_impl.cvtop
+    | Ty.Ty_str -> String_impl.cvtop
+    | Ty.Ty_bitv 8 -> I8.cvtop
+    | Ty.Ty_bitv 32 -> I32.cvtop
+    | Ty.Ty_bitv 64 -> I64.cvtop
+    | Ty.Ty_fp 32 -> Float32_impl.cvtop
+    | Ty.Ty_fp 64 -> Float64_impl.cvtop
+    | Ty.Ty_bitv _ | Ty_fp _ -> assert false
+
+  let rec encode_expr (hte : Expr.t) : term M.t =
+    match Expr.view hte with
+    | Val value -> v value
+    | Ptr (base, offset) ->
+      let* base' = v (Num (I32 base)) in
+      let* offset' = encode_expr offset in
+      I32.binop Add base' offset'
+    | Unop (ty, op, e) ->
+      let* e = encode_expr e in
+      unop ty op e
+    | Binop (ty, op, e1, e2) ->
+      let* e1 = encode_expr e1 in
+      let* e2 = encode_expr e2 in
+      binop ty op e1 e2
+    | Triop (ty, op, e1, e2, e3) ->
+      let* e1 = encode_expr e1 in
+      let* e2 = encode_expr e2 in
+      let* e3 = encode_expr e3 in
+      triop ty op e1 e2 e3
+    | Relop (ty, op, e1, e2) ->
+      let* e1 = encode_expr e1 in
+      let* e2 = encode_expr e2 in
+      relop ty op e1 e2
+    | Cvtop (ty, op, e) ->
+      let* e = encode_expr e in
+      cvtop ty op e
+    | Symbol s ->
+      let x = Symbol.to_string s in
+      let* ty = get_type @@ Symbol.type_of s in
+      const x ty
+    | Extract (e, h, l) ->
+      let* e = encode_expr e in
+      M.Bitv.extract e ~high:((h * 8) - 1) ~low:(l * 8)
+    | Concat (e1, e2) ->
+      let* e1 = encode_expr e1 in
+      let* e2 = encode_expr e2 in
+      M.Bitv.concat e1 e2
+
+  (* TODO: pp_smt *)
+  let pp_smt ?status:_ _ _ = assert false
+
+  let value ({ node = m; cont } : model) (c : Expr.t) : Value.t =
+    let open M in
+    let v =
+      let* term = encode_expr c in
+      let v = Model.eval ~completion:true m term |> Option.get in
+      match Expr.ty c with
+      | Ty_int -> M.Cont.return @@ Value.Int (Interp.to_int v)
+      | Ty_real -> M.Cont.return @@ Value.Real (Interp.to_real v)
+      | Ty_bool ->
+        M.Cont.return @@ if Interp.to_bool v then Value.True else Value.False
+      | Ty_str ->
+        let+ str = Interp.to_string v in
+        Value.Str str
+      | Ty_bitv 8 ->
+        let i8 = Interp.to_bitv v 8 in
+        M.Cont.return @@ Value.Num (I8 (Int64.to_int i8))
+      | Ty_bitv 32 ->
+        let i32 = Interp.to_bitv v 32 in
+        M.Cont.return @@ Value.Num (I32 (Int64.to_int32 i32))
+      | Ty_bitv 64 ->
+        let i64 = Interp.to_bitv v 64 in
+        M.Cont.return @@ Value.Num (I64 i64)
+      | Ty_fp 32 ->
+        let+ float = Interp.to_float v 8 24 in
+        Value.Num (F32 (Int32.bits_of_float float))
+      | Ty_fp 64 ->
+        let+ float = Interp.to_float v 11 53 in
+        Value.Num (F64 (Int64.bits_of_float float))
+      | Ty_bitv _ | Ty_fp _ -> assert false
+    in
+    Cont.run v cont
+
+  let values_of_model ?symbols ({ node = model; cont } as model') =
+    let m = Hashtbl.create 512 in
+    let symbols =
+      match symbols with
+      | None -> Cont.run (Model.get_symbols model) cont
+      | Some symbols -> symbols
+    in
+    List.iter
+      (fun sym ->
+        let v = value model' (Expr.mk_symbol sym) in
+        Hashtbl.replace m sym v )
+      symbols;
+    m
+
+  let set_debug _ = ()
+
+  module Solver = struct
+    let make ?params ?logic () =
+      let cont = make_cont () in
+      let solver = Cont.run (Solver.make ?params ?logic ()) cont in
+      { node = solver; cont }
+
+    let clone { node = solver; cont } =
+      let node = Cont.run (Solver.clone solver) cont in
+      { node; cont }
+
+    let push { node = solver; _ } = Solver.push solver
+
+    let pop { node = solver; _ } n = Solver.pop solver n
+
+    let reset { node = solver; _ } = Solver.reset solver
+
+    let add { node = solver; cont } (exprs : Expr.t list) =
+      let exprs = List.map (fun e -> Cont.run (encode_expr e) cont) exprs in
+      Solver.add solver exprs
+
+    let check { node = solver; cont } ~assumptions =
+      let assumptions =
+        List.map (fun e -> Cont.run (encode_expr e) cont) assumptions
+      in
+      Solver.check solver ~assumptions
+
+    let model { node = solver; cont } =
+      Option.map (fun node -> { node; cont }) (Solver.model solver)
+
+    let add_simplifier { node = solver; cont } =
+      { node = Cont.run (Solver.add_simplifier solver) cont; cont }
+
+    let interrupt { cont; _ } = Cont.run (Solver.interrupt ()) cont
+
+    let pp_statistics fmt { node = solver; _ } = Solver.pp_statistics fmt solver
+  end
+
+  module Optimizer = struct
+    let make () =
+      let cont = make_cont () in
+      let opt = Cont.run (Optimizer.make ()) cont in
+      { node = opt; cont }
+
+    let push { node = opt; _ } = Optimizer.push opt
+
+    let pop { node = opt; _ } = Optimizer.pop opt
+
+    let add { node = opt; cont } (exprs : Expr.t list) =
+      let unit =
+        let+ terms =
+          List.fold_left
+            (fun acc e ->
+              let* acc in
+              let+ term = encode_expr e in
+              term :: acc )
+            (Cont.return []) exprs
+        in
+        Optimizer.add opt terms
+      in
+      Cont.run unit cont
+
+    let check { node = opt; _ } = Optimizer.check opt
+
+    let model { node = opt; cont } =
+      Option.map (fun node -> { node; cont }) (Optimizer.model opt)
+
+    let maximize { node = opt; cont } (expr : Expr.t) =
+      let handle =
+        let+ term = encode_expr expr in
+        Optimizer.maximize opt term
+      in
+      Cont.run handle cont
+
+    let minimize { node = opt; cont } (expr : Expr.t) =
+      let handle =
+        let+ expr = encode_expr expr in
+        Optimizer.minimize opt expr
+      in
+      Cont.run handle cont
+
+    let interrupt { cont; _ } = Cont.run (Optimizer.interrupt ()) cont
+
+    let pp_statistics fmt { node = opt; _ } = Optimizer.pp_statistics fmt opt
+  end
+end
+
+module Make' (M : Mappings_intf.M) : S = Make (M)

--- a/lib/mappings_intf.ml
+++ b/lib/mappings_intf.ml
@@ -3,22 +3,362 @@ type satisfiability =
   | Unsatisfiable
   | Unknown
 
+module type M = sig
+  type ty
+
+  type term
+
+  type interp
+
+  type model
+
+  type solver
+
+  type handle
+
+  type optimizer
+
+  type cont
+
+  type 'a t
+
+  val make_cont : unit -> cont
+
+  module Cont : sig
+    val return : 'a -> 'a t
+
+    val bind : 'a t -> ('a -> 'b t) -> 'b t
+
+    val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+
+    val map : 'a t -> ('a -> 'b) -> 'b t
+
+    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+
+    val run : 'a t -> cont -> 'a
+  end
+
+  val true_ : term t
+
+  val false_ : term t
+
+  val int : int -> term t
+
+  val real : float -> term t
+
+  val const : string -> ty -> term t
+
+  val not_ : term -> term t
+
+  val and_ : term -> term -> term t
+
+  val or_ : term -> term -> term t
+
+  val xor : term -> term -> term t
+
+  val eq : term -> term -> term t
+
+  val distinct : term list -> term t
+
+  val ite : term -> term -> term -> term t
+
+  module Types : sig
+    val int : ty t
+
+    val real : ty t
+
+    val bool : ty t
+
+    val string : ty t
+
+    val bitv : int -> ty t
+
+    val float : int -> int -> ty t
+
+    val ty : term -> ty
+
+    val to_ety : ty -> Ty.t t
+  end
+
+  module Interp : sig
+    val to_int : interp -> int
+
+    val to_real : interp -> float
+
+    val to_bool : interp -> bool
+
+    val to_string : interp -> string t
+
+    val to_bitv : interp -> int -> int64
+
+    val to_float : interp -> int -> int -> float t
+  end
+
+  module Int : sig
+    val neg : term -> term t
+
+    val to_real : term -> term t
+
+    val add : term -> term -> term t
+
+    val sub : term -> term -> term t
+
+    val mul : term -> term -> term t
+
+    val div : term -> term -> term t
+
+    val rem : term -> term -> term t
+
+    val pow : term -> term -> term t
+
+    val lt : term -> term -> term t
+
+    val le : term -> term -> term t
+
+    val gt : term -> term -> term t
+
+    val ge : term -> term -> term t
+  end
+
+  module Real : sig
+    val neg : term -> term t
+
+    val to_int : term -> term t
+
+    val add : term -> term -> term t
+
+    val sub : term -> term -> term t
+
+    val mul : term -> term -> term t
+
+    val div : term -> term -> term t
+
+    val pow : term -> term -> term t
+
+    val lt : term -> term -> term t
+
+    val le : term -> term -> term t
+
+    val gt : term -> term -> term t
+
+    val ge : term -> term -> term t
+  end
+
+  module String : sig
+    val v : string -> term t
+
+    val length : term -> term t
+
+    val to_code : term -> term t
+
+    val of_code : term -> term t
+
+    val at : term -> pos:term -> term t
+
+    val concat : term -> term -> term t
+
+    val sub : term -> pos:term -> len:term -> term t
+  end
+
+  module Bitv : sig
+    val v : string -> int -> term t
+
+    val neg : term -> term t
+
+    val lognot : term -> term t
+
+    val add : term -> term -> term t
+
+    val sub : term -> term -> term t
+
+    val mul : term -> term -> term t
+
+    val div : term -> term -> term t
+
+    val div_u : term -> term -> term t
+
+    val logor : term -> term -> term t
+
+    val logand : term -> term -> term t
+
+    val logxor : term -> term -> term t
+
+    val shl : term -> term -> term t
+
+    val ashr : term -> term -> term t
+
+    val lshr : term -> term -> term t
+
+    val rem : term -> term -> term t
+
+    val rem_u : term -> term -> term t
+
+    val rotate_left : term -> term -> term t
+
+    val rotate_right : term -> term -> term t
+
+    val lt : term -> term -> term t
+
+    val lt_u : term -> term -> term t
+
+    val le : term -> term -> term t
+
+    val le_u : term -> term -> term t
+
+    val gt : term -> term -> term t
+
+    val gt_u : term -> term -> term t
+
+    val ge : term -> term -> term t
+
+    val ge_u : term -> term -> term t
+
+    val concat : term -> term -> term t
+
+    val extract : term -> high:int -> low:int -> term t
+
+    val zero_extend : int -> term -> term t
+
+    val sign_extend : int -> term -> term t
+  end
+
+  module Float : sig
+    (* Rounding modes *)
+    module Rounding_mode : sig
+      (* Round nearest ties to even *)
+      val rne : term t
+
+      (* Round nearest ties to away *)
+      val rna : term t
+
+      (* Round toward positive *)
+      val rtp : term t
+
+      (* Round toward negative *)
+      val rtn : term t
+
+      (* Round toward zero *)
+      val rtz : term t
+    end
+
+    val v : float -> int -> int -> term t
+
+    val neg : term -> term t
+
+    val abs : term -> term t
+
+    (* [sqrt ~rm t] where [rm] is the rounding mode *)
+    val sqrt : rm:term -> term -> term t
+
+    val is_nan : term -> term t
+
+    (* [round_to_integral ~rm t] where [rm] is the rounding mode *)
+    val round_to_integral : rm:term -> term -> term t
+
+    (* [add ~rm t1 t2] where [rm] is the rounding mode *)
+    val add : rm:term -> term -> term -> term t
+
+    (* [sub ~rm t1 t2] where [rm] is the rounding mode *)
+    val sub : rm:term -> term -> term -> term t
+
+    (* [mul ~rm t1 t2] where [rm] is the rounding mode *)
+    val mul : rm:term -> term -> term -> term t
+
+    (* [div ~rm t1 t2] where [rm] is the rounding mode *)
+    val div : rm:term -> term -> term -> term t
+
+    val min : term -> term -> term t
+
+    val max : term -> term -> term t
+
+    val rem : term -> term -> term t
+
+    val eq : term -> term -> term t
+
+    val lt : term -> term -> term t
+
+    val le : term -> term -> term t
+
+    val gt : term -> term -> term t
+
+    val ge : term -> term -> term t
+
+    val to_fp : int -> int -> rm:term -> term -> term t
+
+    val sbv_to_fp : int -> int -> rm:term -> term -> term t
+
+    val ubv_to_fp : int -> int -> rm:term -> term -> term t
+
+    val to_ubv : int -> rm:term -> term -> term t
+
+    val to_sbv : int -> rm:term -> term -> term t
+
+    val of_ieee_bv : int -> int -> term -> term t
+
+    val to_ieee_bv : term -> term t
+  end
+
+  module Model : sig
+    val get_symbols : model -> Symbol.t list t
+
+    val eval : ?completion:bool -> model -> term -> interp option
+  end
+
+  module Solver : sig
+    val make : ?params:Params.t -> ?logic:Ty.logic -> unit -> solver t
+
+    val clone : solver -> solver t
+
+    val push : solver -> unit
+
+    val pop : solver -> int -> unit
+
+    val reset : solver -> unit
+
+    val add : solver -> term list -> unit
+
+    val check : solver -> assumptions:term list -> satisfiability
+
+    val model : solver -> model option
+
+    val add_simplifier : solver -> solver t
+
+    val interrupt : unit -> unit t
+
+    val pp_statistics : Format.formatter -> solver -> unit
+  end
+
+  module Optimizer : sig
+    val make : unit -> optimizer t
+
+    val push : optimizer -> unit
+
+    val pop : optimizer -> unit
+
+    val add : optimizer -> term list -> unit
+
+    val check : optimizer -> satisfiability
+
+    val model : optimizer -> model option
+
+    val maximize : optimizer -> term -> handle
+
+    val minimize : optimizer -> term -> handle
+
+    val interrupt : unit -> unit t
+
+    val pp_statistics : Format.formatter -> optimizer -> unit
+  end
+end
+
 module type S = sig
   type model
 
   type solver
 
-  type status
-
   type optimize
 
   type handle
-
-  val update_param_value : 'a Params.param -> 'a -> unit
-
-  val interrupt : unit -> unit
-
-  val satisfiability : status -> satisfiability
 
   val value : model -> Expr.t -> Value.t
 
@@ -29,7 +369,7 @@ module type S = sig
   val set_debug : bool -> unit
 
   module Solver : sig
-    val make : ?logic:Ty.logic -> unit -> solver
+    val make : ?params:Params.t -> ?logic:Ty.logic -> unit -> solver
 
     val add_simplifier : solver -> solver
 
@@ -43,9 +383,11 @@ module type S = sig
 
     val add : solver -> Expr.t list -> unit
 
-    val check : solver -> assumptions:Expr.t list -> status
+    val check : solver -> assumptions:Expr.t list -> satisfiability
 
     val model : solver -> model option
+
+    val interrupt : solver -> unit
 
     val pp_statistics : Format.formatter -> solver -> unit
   end
@@ -59,13 +401,15 @@ module type S = sig
 
     val add : optimize -> Expr.t list -> unit
 
-    val check : optimize -> status
+    val check : optimize -> satisfiability
 
     val model : optimize -> model option
 
     val maximize : optimize -> Expr.t -> handle
 
     val minimize : optimize -> Expr.t -> handle
+
+    val interrupt : optimize -> unit
 
     val pp_statistics : Format.formatter -> optimize -> unit
   end

--- a/lib/optimizer.ml
+++ b/lib/optimizer.ml
@@ -21,8 +21,7 @@ module Make (M : Mappings_intf.S) = struct
 
   let add (opt : t) (es : Expr.t list) : unit = O.add opt es
 
-  let check (opt : t) =
-    M.satisfiability (time_call ~f:(fun () -> O.check opt) ~accum:solver_time)
+  let check (opt : t) = time_call ~f:(fun () -> O.check opt) ~accum:solver_time
 
   let model opt =
     let+ model = O.model opt in

--- a/lib/solver_intf.ml
+++ b/lib/solver_intf.ml
@@ -24,7 +24,7 @@ module type S = sig
   val create : ?params:Params.t -> ?logic:Ty.logic -> unit -> t
 
   (** Interrupt solver. *)
-  val interrupt : unit -> unit
+  val interrupt : t -> unit
 
   (** Clone a given solver. *)
   val clone : t -> t

--- a/lib/z3_mappings.ml
+++ b/lib/z3_mappings.ml
@@ -1,3 +1,5 @@
+include Mappings_intf
+
 module Fresh = struct
   module Make () = struct
     let err = Log.err
@@ -7,8 +9,6 @@ module Fresh = struct
     type model = Z3.Model.model
 
     type solver = Z3.Solver.solver
-
-    type status = Z3.Solver.status
 
     type optimize = Z3.Optimize.optimize
 
@@ -586,25 +586,16 @@ module Fresh = struct
     (*   let t' = match t with Forall -> true | Exists -> false in *)
     (*   encode_quantifier t' vars body' patterns' *)
 
-    let update_param_value (type a) (param : a Params.param) (value : a) =
+    let set_params (params : Params.t) =
       let module P = Z3.Params in
-      match param with
-      | Params.Timeout ->
-        P.update_param_value ctx "timeout" (string_of_int value)
-      | Params.Model -> P.update_param_value ctx "model" (string_of_bool value)
-      | Params.Unsat_core ->
-        P.update_param_value ctx "unsat_core" (string_of_bool value)
-      | Params.Ematching ->
-        Z3.set_global_param "smt.ematching" (string_of_bool value)
-
-    let interrupt () = Z3.Tactic.interrupt ctx
-
-    let satisfiability =
-      let open Mappings_intf in
-      function
-      | Z3.Solver.SATISFIABLE -> Satisfiable
-      | Z3.Solver.UNSATISFIABLE -> Unsatisfiable
-      | Z3.Solver.UNKNOWN -> Unknown
+      Z3.set_global_param "smt.ematching"
+        (string_of_bool @@ Params.get params Ematching);
+      P.update_param_value ctx "timeout"
+        (string_of_int @@ Params.get params Timeout);
+      P.update_param_value ctx "model"
+        (string_of_bool @@ Params.get params Model);
+      P.update_param_value ctx "unsat_core"
+        (string_of_bool @@ Params.get params Unsat_core)
 
     let pp_smt ?status fmt (es : Expr.t list) =
       let st = match status with Some b -> string_of_bool b | None -> "" in
@@ -620,7 +611,8 @@ module Fresh = struct
       Format.fprintf fmt "(%s %s)" key value
 
     module Solver = struct
-      let make ?logic () : solver =
+      let make ?params ?logic () : solver =
+        Option.iter set_params params;
         let logic =
           Option.map
             (fun l ->
@@ -651,9 +643,14 @@ module Fresh = struct
       let add s es = Z3.Solver.add s (List.map encode_expr es)
 
       let check s ~assumptions =
-        Z3.Solver.check s (List.map encode_expr assumptions)
+        match Z3.Solver.check s (List.map encode_expr assumptions) with
+        | Z3.Solver.UNKNOWN -> Unknown
+        | Z3.Solver.SATISFIABLE -> Satisfiable
+        | Z3.Solver.UNSATISFIABLE -> Unsatisfiable
 
       let model s = Z3.Solver.get_model s
+
+      let interrupt _ = Z3.Tactic.interrupt ctx
 
       let pp_statistics fmt solver =
         let module Entry = Z3.Statistics.Entry in
@@ -673,13 +670,19 @@ module Fresh = struct
 
       let add o es = Z3.Optimize.add o (List.map encode_expr es)
 
-      let check o = Z3.Optimize.check o
+      let check o =
+        match Z3.Optimize.check o with
+        | Z3.Solver.UNKNOWN -> Unknown
+        | Z3.Solver.SATISFIABLE -> Satisfiable
+        | Z3.Solver.UNSATISFIABLE -> Unsatisfiable
 
       let model o = Z3.Optimize.get_model o
 
       let maximize o e = Z3.Optimize.maximize o (encode_expr e)
 
       let minimize o e = Z3.Optimize.minimize o (encode_expr e)
+
+      let interrupt _ = Z3.Tactic.interrupt ctx
 
       let pp_statistics fmt o =
         let module Entry = Z3.Statistics.Entry in

--- a/lib/z3_mappings2.ml
+++ b/lib/z3_mappings2.ml
@@ -1,0 +1,463 @@
+include Mappings_intf
+module P = Params
+module Sym = Symbol
+
+let err = Log.err
+
+module Impl = struct
+  open Z3
+
+  type ty = Sort.sort
+
+  type term = Expr.expr
+
+  type interp = term
+
+  type model = Model.model
+
+  type solver = Solver.solver
+
+  type handle = Optimize.handle
+
+  type optimizer = Optimize.optimize
+
+  type cont = context
+
+  type 'a t = cont -> 'a
+
+  let make_cont () = mk_context []
+
+  module Cont = struct
+    let return v _ = v
+
+    let bind (v : 'a t) (f : 'a -> 'b t) : 'b t =
+     fun (ctx : cont) ->
+      let v = v ctx in
+      (f v) ctx
+
+    let ( let* ) v f = bind v f
+
+    let map (v : 'a t) (f : 'a -> 'b) : 'b t =
+     fun (ctx : cont) ->
+      let v = v ctx in
+      f v
+
+    let ( let+ ) v f = map v f
+
+    let run (v : 'a t) (ctx : cont) = v ctx
+  end
+
+  let true_ = Boolean.mk_true
+
+  let false_ = Boolean.mk_false
+
+  let int i ctx = Arithmetic.Integer.mk_numeral_i ctx i
+
+  let real f ctx = Arithmetic.Real.mk_numeral_s ctx (Float.to_string f)
+
+  let const sym ty ctx = Expr.mk_const_s ctx sym ty
+
+  let not_ e ctx = Boolean.mk_not ctx e
+
+  let and_ e1 e2 ctx = Boolean.mk_and ctx [ e1; e2 ]
+
+  let or_ e1 e2 ctx = Boolean.mk_or ctx [ e1; e2 ]
+
+  let xor e1 e2 ctx = Boolean.mk_xor ctx e1 e2
+
+  let eq e1 e2 ctx = Boolean.mk_eq ctx e1 e2
+
+  let distinct es ctx = Boolean.mk_distinct ctx es
+
+  let ite cond e1 e2 ctx = Boolean.mk_ite ctx cond e1 e2
+
+  module Types = struct
+    let int ctx = Arithmetic.Integer.mk_sort ctx
+
+    let real ctx = Arithmetic.Real.mk_sort ctx
+
+    let bool ctx = Boolean.mk_sort ctx
+
+    let string ctx = Seq.mk_string_sort ctx
+
+    let bitv n ctx = BitVector.mk_sort ctx n
+
+    let float eb sb ctx = FloatingPoint.mk_sort ctx eb sb
+
+    let ty term = Expr.get_sort term
+
+    let to_ety sort ctx =
+      match Sort.get_sort_kind sort with
+      | Z3enums.INT_SORT -> Ty.Ty_int
+      | Z3enums.REAL_SORT -> Ty.Ty_real
+      | Z3enums.BOOL_SORT -> Ty.Ty_bool
+      | Z3enums.SEQ_SORT -> Ty.Ty_str
+      | Z3enums.BV_SORT -> Ty.Ty_bitv (Z3.BitVector.get_size sort)
+      | Z3enums.FLOATING_POINT_SORT ->
+        let ebits = Z3.FloatingPoint.get_ebits ctx sort in
+        let sbits = Z3.FloatingPoint.get_sbits ctx sort in
+        Ty.Ty_fp (ebits + sbits)
+      | _ -> assert false
+  end
+
+  module Interp = struct
+    let to_int interp = Z.to_int @@ Arithmetic.Integer.get_big_int interp
+
+    let to_real interp = Q.to_float @@ Arithmetic.Real.get_ratio interp
+
+    let to_bool interp =
+      match Boolean.get_bool_value interp with
+      | Z3enums.L_TRUE -> true
+      | Z3enums.L_FALSE -> false
+      | Z3enums.L_UNDEF ->
+        err "Z3_mappings2: to_bool: something went terribly wrong!"
+
+    let to_string interp ctx = Seq.get_string ctx interp
+
+    let to_bitv interp _n =
+      assert (Expr.is_numeral interp);
+      let set (s : string) (i : int) (n : char) =
+        let bs = Bytes.of_string s in
+        Bytes.set bs i n;
+        Bytes.to_string bs
+      in
+      Int64.of_string (set (Expr.to_string interp) 0 '0')
+
+    let to_float fp _eb _sb ctx =
+      assert (Expr.is_numeral fp);
+      if FloatingPoint.is_numeral_nan ctx fp then Float.nan
+      else if FloatingPoint.is_numeral_inf ctx fp then
+        if FloatingPoint.is_numeral_negative ctx fp then Float.neg_infinity
+        else Float.infinity
+      else if FloatingPoint.is_numeral_zero ctx fp then
+        if FloatingPoint.is_numeral_negative ctx fp then Float.neg Float.zero
+        else Float.zero
+      else
+        let sort = Expr.get_sort fp in
+        let ebits = FloatingPoint.get_ebits ctx sort in
+        let sbits = FloatingPoint.get_sbits ctx sort in
+        let _, sign = FloatingPoint.get_numeral_sign ctx fp in
+        (* true => biased exponent *)
+        let _, exponent = FloatingPoint.get_numeral_exponent_int ctx fp true in
+        let _, significand =
+          FloatingPoint.get_numeral_significand_uint ctx fp
+        in
+        let fp_bits =
+          Int64.(
+            logor
+              (logor
+                 (shift_left (of_int sign) (ebits + sbits - 1))
+                 (shift_left exponent (sbits - 1)) )
+              significand )
+        in
+        match ebits + sbits with
+        | 32 -> Int32.float_of_bits @@ Int64.to_int32 fp_bits
+        | 64 -> Int64.float_of_bits fp_bits
+        | _ -> assert false
+  end
+
+  module Int = struct
+    let neg e ctx = Arithmetic.mk_unary_minus ctx e
+
+    let to_real e ctx = Arithmetic.Integer.mk_int2real ctx e
+
+    let add e1 e2 ctx = Arithmetic.mk_add ctx [ e1; e2 ]
+
+    let sub e1 e2 ctx = Arithmetic.mk_sub ctx [ e1; e2 ]
+
+    let mul e1 e2 ctx = Arithmetic.mk_mul ctx [ e1; e2 ]
+
+    let div e1 e2 ctx = Arithmetic.mk_div ctx e1 e2
+
+    let rem e1 e2 ctx = Arithmetic.Integer.mk_rem ctx e1 e2
+
+    let pow e1 e2 ctx = Arithmetic.mk_power ctx e1 e2
+
+    let lt e1 e2 ctx = Arithmetic.mk_lt ctx e1 e2
+
+    let le e1 e2 ctx = Arithmetic.mk_le ctx e1 e2
+
+    let gt e1 e2 ctx = Arithmetic.mk_gt ctx e1 e2
+
+    let ge e1 e2 ctx = Arithmetic.mk_ge ctx e1 e2
+  end
+
+  module Real = struct
+    let neg e ctx = Arithmetic.mk_unary_minus ctx e
+
+    let to_int e ctx = Arithmetic.Real.mk_real2int ctx e
+
+    let add e1 e2 ctx = Arithmetic.mk_add ctx [ e1; e2 ]
+
+    let sub e1 e2 ctx = Arithmetic.mk_sub ctx [ e1; e2 ]
+
+    let mul e1 e2 ctx = Arithmetic.mk_mul ctx [ e1; e2 ]
+
+    let div e1 e2 ctx = Arithmetic.mk_div ctx e1 e2
+
+    let pow e1 e2 ctx = Arithmetic.mk_power ctx e1 e2
+
+    let lt e1 e2 ctx = Arithmetic.mk_lt ctx e1 e2
+
+    let le e1 e2 ctx = Arithmetic.mk_le ctx e1 e2
+
+    let gt e1 e2 ctx = Arithmetic.mk_gt ctx e1 e2
+
+    let ge e1 e2 ctx = Arithmetic.mk_ge ctx e1 e2
+  end
+
+  module String = struct
+    let v s ctx = Seq.mk_string ctx s
+
+    let length e ctx = Seq.mk_seq_length ctx e
+
+    let to_code e ctx = Seq.mk_string_to_code ctx e
+
+    let of_code e ctx = Seq.mk_string_from_code ctx e
+
+    let at str ~pos ctx = Seq.mk_seq_at ctx str pos
+
+    let concat e1 e2 ctx = Seq.mk_seq_concat ctx [ e1; e2 ]
+
+    let sub str ~pos ~len ctx = Seq.mk_seq_extract ctx str pos len
+  end
+
+  module Bitv = struct
+    let v bv bitwidth ctx = BitVector.mk_numeral ctx bv bitwidth
+
+    let neg e ctx = BitVector.mk_neg ctx e
+
+    let lognot e ctx = BitVector.mk_not ctx e
+
+    let add e1 e2 ctx = BitVector.mk_add ctx e1 e2
+
+    let sub e1 e2 ctx = BitVector.mk_sub ctx e1 e2
+
+    let mul e1 e2 ctx = BitVector.mk_mul ctx e1 e2
+
+    let div e1 e2 ctx = BitVector.mk_sdiv ctx e1 e2
+
+    let div_u e1 e2 ctx = BitVector.mk_udiv ctx e1 e2
+
+    let logor e1 e2 ctx = BitVector.mk_or ctx e1 e2
+
+    let logand e1 e2 ctx = BitVector.mk_and ctx e1 e2
+
+    let logxor e1 e2 ctx = BitVector.mk_xor ctx e1 e2
+
+    let shl e1 e2 ctx = BitVector.mk_shl ctx e1 e2
+
+    let ashr e1 e2 ctx = BitVector.mk_ashr ctx e1 e2
+
+    let lshr e1 e2 ctx = BitVector.mk_lshr ctx e1 e2
+
+    let rem e1 e2 ctx = BitVector.mk_srem ctx e1 e2
+
+    let rem_u e1 e2 ctx = BitVector.mk_urem ctx e1 e2
+
+    let rotate_left e1 e2 ctx = BitVector.mk_ext_rotate_left ctx e1 e2
+
+    let rotate_right e1 e2 ctx = BitVector.mk_ext_rotate_right ctx e1 e2
+
+    let lt e1 e2 ctx = BitVector.mk_slt ctx e1 e2
+
+    let lt_u e1 e2 ctx = BitVector.mk_ult ctx e1 e2
+
+    let le e1 e2 ctx = BitVector.mk_sle ctx e1 e2
+
+    let le_u e1 e2 ctx = BitVector.mk_ule ctx e1 e2
+
+    let gt e1 e2 ctx = BitVector.mk_sgt ctx e1 e2
+
+    let gt_u e1 e2 ctx = BitVector.mk_ugt ctx e1 e2
+
+    let ge e1 e2 ctx = BitVector.mk_sge ctx e1 e2
+
+    let ge_u e1 e2 ctx = BitVector.mk_uge ctx e1 e2
+
+    let concat e1 e2 ctx = BitVector.mk_concat ctx e1 e2
+
+    let extract e ~high ~low ctx = BitVector.mk_extract ctx high low e
+
+    let zero_extend n e ctx = BitVector.mk_zero_ext ctx n e
+
+    let sign_extend n e ctx = BitVector.mk_sign_ext ctx n e
+  end
+
+  module Float = struct
+    module Rounding_mode = struct
+      let rne ctx = FloatingPoint.RoundingMode.mk_rne ctx
+
+      let rna ctx = FloatingPoint.RoundingMode.mk_rna ctx
+
+      let rtp ctx = FloatingPoint.RoundingMode.mk_rtp ctx
+
+      let rtn ctx = FloatingPoint.RoundingMode.mk_rtn ctx
+
+      let rtz ctx = FloatingPoint.RoundingMode.mk_rtz ctx
+    end
+
+    let v f eb sb ctx = FloatingPoint.mk_numeral_f ctx f (Types.float eb sb ctx)
+
+    let neg e ctx = FloatingPoint.mk_neg ctx e
+
+    let abs e ctx = FloatingPoint.mk_abs ctx e
+
+    let sqrt ~rm e ctx = FloatingPoint.mk_sqrt ctx rm e
+
+    let is_nan e ctx = FloatingPoint.mk_is_nan ctx e
+
+    let round_to_integral ~rm e ctx =
+      FloatingPoint.mk_round_to_integral ctx rm e
+
+    let add ~rm e1 e2 ctx = FloatingPoint.mk_add ctx rm e1 e2
+
+    let sub ~rm e1 e2 ctx = FloatingPoint.mk_sub ctx rm e1 e2
+
+    let mul ~rm e1 e2 ctx = FloatingPoint.mk_mul ctx rm e1 e2
+
+    let div ~rm e1 e2 ctx = FloatingPoint.mk_div ctx rm e1 e2
+
+    let min e1 e2 ctx = FloatingPoint.mk_min ctx e1 e2
+
+    let max e1 e2 ctx = FloatingPoint.mk_max ctx e1 e2
+
+    let rem e1 e2 ctx = FloatingPoint.mk_rem ctx e1 e2
+
+    let eq e1 e2 ctx = FloatingPoint.mk_eq ctx e1 e2
+
+    let lt e1 e2 ctx = FloatingPoint.mk_lt ctx e1 e2
+
+    let le e1 e2 ctx = FloatingPoint.mk_leq ctx e1 e2
+
+    let gt e1 e2 ctx = FloatingPoint.mk_gt ctx e1 e2
+
+    let ge e1 e2 ctx = FloatingPoint.mk_geq ctx e1 e2
+
+    let to_fp eb sb ~rm fp ctx =
+      FloatingPoint.mk_to_fp_float ctx rm fp (Types.float eb sb ctx)
+
+    let sbv_to_fp eb sb ~rm bv ctx =
+      FloatingPoint.mk_to_fp_signed ctx rm bv (Types.float eb sb ctx)
+
+    let ubv_to_fp eb sb ~rm bv ctx =
+      FloatingPoint.mk_to_fp_unsigned ctx rm bv (Types.float eb sb ctx)
+
+    let to_ubv n ~rm fp ctx = FloatingPoint.mk_to_ubv ctx rm fp n
+
+    let to_sbv n ~rm fp ctx = FloatingPoint.mk_to_sbv ctx rm fp n
+
+    let of_ieee_bv eb sb bv ctx =
+      FloatingPoint.mk_to_fp_bv ctx bv (Types.float eb sb ctx)
+
+    let to_ieee_bv fp ctx = FloatingPoint.mk_to_ieee_bv ctx fp
+  end
+
+  module Model = struct
+    let get_symbols model ctx =
+      List.map
+        (fun const ->
+          let x = Symbol.to_string (FuncDecl.get_name const) in
+          let t = Types.to_ety (FuncDecl.get_range const) ctx in
+          Sym.mk_symbol t x )
+        (Model.get_const_decls model)
+
+    let eval ?(completion = false) model term = Model.eval model term completion
+  end
+
+  let pp_entry fmt (entry : Statistics.Entry.statistics_entry) =
+    let key = Statistics.Entry.get_key entry in
+    let value = Statistics.Entry.to_string_value entry in
+    Format.fprintf fmt "(%s %s)" key value
+
+  let pp_statistics fmt (stats : Statistics.statistics) =
+    let entries = Statistics.get_entries stats in
+    Format.pp_print_list
+      ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
+      pp_entry fmt entries
+
+  let _set_and_build_params (params : P.t) : (string * string) list =
+    Z3.set_global_param "smt.ematching"
+      (string_of_bool @@ P.get params Ematching);
+    [ ("timeout", string_of_int @@ P.get params Timeout)
+    ; ("model", string_of_bool @@ P.get params Model)
+    ; ("unsat_core", string_of_bool @@ P.get params Unsat_core)
+    ]
+
+  module Solver = struct
+    let make ?params:_ ?logic () ctx =
+      (* let params = Option.fold params ~none:[] ~some:set_and_build_params in *)
+      (* let ctx = mk_context params in *)
+      let logic =
+        Option.map
+          (fun l ->
+            Format.kasprintf (Z3.Symbol.mk_string ctx) "%a" Ty.pp_logic l )
+          logic
+      in
+      Z3.Solver.mk_solver ctx logic
+
+    let clone solver ctx = Solver.translate solver ctx
+
+    let push solver = Solver.push solver
+
+    let pop solver n = Solver.pop solver n
+
+    let reset solver = Solver.reset solver
+
+    let add solver terms = Solver.add solver terms
+
+    let check solver ~assumptions =
+      match Solver.check solver assumptions with
+      | Solver.UNKNOWN -> Unknown
+      | Solver.SATISFIABLE -> Satisfiable
+      | Solver.UNSATISFIABLE -> Unsatisfiable
+
+    let model solver = Solver.get_model solver
+
+    let add_simplifier solver ctx =
+      let simplify = Simplifier.mk_simplifier ctx "simplify" in
+      let solver_eqs = Simplifier.mk_simplifier ctx "solve-eqs" in
+      let then_ =
+        List.map
+          (Simplifier.mk_simplifier ctx)
+          [ "elim-unconstrained"; "propagate-values"; "simplify" ]
+      in
+      Simplifier.and_then ctx simplify solver_eqs then_
+      |> Solver.add_simplifier ctx solver
+
+    let interrupt () = Tactic.interrupt
+
+    let pp_statistics fmt solver =
+      pp_statistics fmt @@ Solver.get_statistics solver
+  end
+
+  module Optimizer = struct
+    let make () = Optimize.mk_opt
+
+    let push opt = Optimize.push opt
+
+    let pop opt = Optimize.pop opt
+
+    let add opt terms = Optimize.add opt terms
+
+    let check opt =
+      match Optimize.check opt with
+      | Z3.Solver.UNKNOWN -> Unknown
+      | Z3.Solver.SATISFIABLE -> Satisfiable
+      | Z3.Solver.UNSATISFIABLE -> Unsatisfiable
+
+    let model opt = Optimize.get_model opt
+
+    let maximize opt term = Optimize.maximize opt term
+
+    let minimize opt term = Optimize.minimize opt term
+
+    let interrupt () = Tactic.interrupt
+
+    let pp_statistics fmt opt = pp_statistics fmt @@ Optimize.get_statistics opt
+  end
+end
+
+module Impl' : M = Impl
+
+include Mappings.Make (Impl)

--- a/lib/z3_mappings2.mli
+++ b/lib/z3_mappings2.mli
@@ -1,0 +1,2 @@
+(** @inline *)
+include Mappings_intf.S


### PR DESCRIPTION
Creates a parametric mappings module that uses a
continuation to pass around solver contexts.